### PR TITLE
Address sqlite findAll bug

### DIFF
--- a/sequelize.js
+++ b/sequelize.js
@@ -48,7 +48,7 @@ function beforeSave(record, options) {
 function afterFind(record) {
   if (!record) {
     return;
-  } else if (record instanceof Array) {
+  } else if (Array.isArray(record)) {
     return record.map(afterFind);
   }
 


### PR DESCRIPTION
When used with sqlite Model.findAll returns an Array of instances.

They not recognised by Keychain as an Array in sequelize.js line 51 (as typeof record returns 'object'). The hook throws a TypeError line 52 is not called and it attempts to run the afterFind hook on the array and not the record. 

Switching to Array.isArray(record) solves the issue.